### PR TITLE
add disposing feature. `addDisposer` and `disposerAll` methods

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+mock-graph.ts

--- a/examples/vite-app/src/App.tsx
+++ b/examples/vite-app/src/App.tsx
@@ -5,9 +5,6 @@ import { MyAppContext, useContainer } from "./hooks"
 import { app } from "./_bl"
 
 const Lol = () => {
-  // console.log(app)
-  // const a = app.get("a")
-  // console.log(a)
   const [b, bErr] = useContainer().b
   console.log("render", b, bErr)
   return <p>123</p>

--- a/iti-react/src/react/library.hook-generator.ts
+++ b/iti-react/src/react/library.hook-generator.ts
@@ -12,9 +12,10 @@ type ContainerSet<Tokens extends keyof Context, Context extends {}> = {
   [S in Tokens]: UnpackTokenFromContext<S, Context>
 }
 
-export function getContainerSetHooks<Context extends object>(
-  reactContext: React.Context<NodeApi<Context>>,
-) {
+export function getContainerSetHooks<
+  Context extends object,
+  DisposeContext extends object,
+>(reactContext: React.Context<NodeApi<Context, DisposeContext>>) {
   function useContainer() {
     const root = useContext(reactContext)
     return useRootStores(root)
@@ -32,7 +33,7 @@ export function getContainerSetHooks<Context extends object>(
         ? [UnpackTokenFromContext<CK, Context> | undefined, any, CK]
         : never
     },
-  >(appRoot: NodeApi<Context>): ContainerGetter {
+  >(appRoot: NodeApi<Context, DisposeContext>): ContainerGetter {
     let FFF = <ContainerGetter>{}
     let tokens = appRoot.getTokens()
 

--- a/iti/README.md
+++ b/iti/README.md
@@ -328,8 +328,6 @@ Plainly removes token and value from an instance
 Related toa a conversation with @moltar
 https://github.com/molszanski/iti/issues/21
 
-Propblem
-
 ```ts
 class DatabaseConnection {
   disconnect(): Promise<void> {
@@ -341,20 +339,20 @@ let node = makeRoot()
   .add({
     db: () => new DatabaseConnection(),
   })
-  .dispose({
-    db: (containers) => containers.db.disconnect(),
+  .addDisposer({
+    // Note that for convenience we provide an instance of the cached value as an argument
+    db: (db) => db.disconnect(),
   })
 
-// disposes of for all resources that have it defined
-await node.dispose()
+// We can dispose nodes individually
+await node.dispose("db")
 
-// under the hood (internals)
-class Node {
-  async dispose(): Promise<void> {
-    await Promise.all(this.getDisposableResources().map((r) => r()))
-  }
-}
+// dispose all resources
+await node.disposeAll()
 ```
+
+please note that `.dispose('token')` doesn't dispose child elements. This would be risky to implement due to reasons explained in
+[dispose-graph.ts.api.spec.ts](./iti/tests/dispose-graph.ts.api.spec.ts.)
 
 # Alternaitves
 

--- a/iti/README.md
+++ b/iti/README.md
@@ -323,6 +323,39 @@ When containers are updated React is updated too via hooks
 
 Plainly removes token and value from an instance
 
+### `dispose`
+
+Related toa a conversation with @moltar
+https://github.com/molszanski/iti/issues/21
+
+Propblem
+
+```ts
+class DatabaseConnection {
+  disconnect(): Promise<void> {
+    // ... disconnect
+  }
+}
+
+let node = makeRoot()
+  .add({
+    db: () => new DatabaseConnection(),
+  })
+  .dispose({
+    db: (containers) => containers.db.disconnect(),
+  })
+
+// disposes of for all resources that have it defined
+await node.dispose()
+
+// under the hood (internals)
+class Node {
+  async dispose(): Promise<void> {
+    await Promise.all(this.getDisposableResources().map((r) => r()))
+  }
+}
+```
+
 # Alternaitves
 
 ## No async support

--- a/iti/src/_utils.ts
+++ b/iti/src/_utils.ts
@@ -23,3 +23,48 @@ export type Assign4<OldContext extends object, NewContext extends object> = {
     ? OldContext[Token]
     : never
 }
+
+export type Prettify<T> = T extends infer U ? { [K in keyof U]: U[K] } : never
+
+export type UnpackFunction<T> = T extends (...args: any) => infer U ? U : T
+export type UnpackObject<T> = {
+  [K in keyof T]: UnpackFunction<T[K]>
+}
+
+export type UnpromisifyObject<T> = {
+  [K in keyof T]: UnPromisify<T[K]>
+}
+// keep
+// type AssignAndUnpackObjects<O1 extends {}, O2 extends {}> = UnpromisifyObject<
+//   UnpackObject<Assign4<O1, O2>>
+// >
+
+export type FullyUnpackObject<T extends {}> = UnpromisifyObject<UnpackObject<T>>
+
+export type KeysOrCb<Context extends {}> =
+  | Array<keyof Context>
+  | ((t: { [K in keyof Context]: K }) => Array<keyof Context>)
+
+export type MyRecord<O extends {}, T> = {
+  [K in keyof O]: T
+}
+export type ContextGetter<Context extends {}> = {
+  [CK in keyof Context]: UnpackFunction<Context[CK]>
+}
+
+export type UnpackFunctionReturn<T> = T extends (arg: T) => infer U ? U : T
+export type ContextGetterWithCache<Context extends {}> = {
+  [CK in keyof Context]: UnpackFunctionReturn<Context[CK]>
+}
+
+export function _intersectionKeys(
+  needle: { [key: string]: any },
+  haystack: { [key: string]: any },
+) {
+  let haystackKeys = Object.keys(haystack)
+  let duplicates = haystackKeys.filter((x) => x in needle)
+  if (duplicates.length === 0) {
+    return undefined
+  }
+  return duplicates.join("', '")
+}

--- a/iti/src/index.ts
+++ b/iti/src/index.ts
@@ -1,7 +1,6 @@
 // Main lib
 export { makeRoot, NodeApi } from "./library.new-root-container"
-export type { UnpackFunction } from "./library.new-root-container"
 
 // Helper types
-export type { GetContainerFormat, UnPromisify } from "./_utils"
+export type { GetContainerFormat, UnPromisify, UnpackFunction } from "./_utils"
 export type { Emitter } from "./nanoevents"

--- a/iti/src/library.new-root-container.ts
+++ b/iti/src/library.new-root-container.ts
@@ -39,6 +39,7 @@ type Events<Context> = {
     newContainer: Context[keyof Context] | null
   }) => void
   containerDeleted: (payload: { key: keyof Context }) => void
+  containerDisposed: (payload: { key: keyof Context }) => void
 
   // Older events
   // containerCreated: (payload: {
@@ -159,6 +160,7 @@ class Node<
     }
     delete this._cache[token]
     delete this._disposeCtx[token]
+    this.ee.emit("containerDisposed", { key: token })
   }
 
   /**

--- a/iti/tests/dispose-graph.ts.api.spec.ts
+++ b/iti/tests/dispose-graph.ts.api.spec.ts
@@ -1,0 +1,75 @@
+import { expect, jest, describe, beforeEach, it } from "@jest/globals"
+import { makeRoot } from "../src"
+import { wait } from "./_utils"
+import { A, X, B, C, D, L, K, E, M, F } from "./mock-graph"
+
+/*
+             ┌─────┐
+             │  A  │
+             └─────┘
+       ┌────────┴────────┐
+       ▼                 ▼
+    ┌─────┐           ┌─────┐
+    │  B  │           │  C  │────────────┐
+    └─────┘           └─────┘            │
+       └────────┬────────┘               │
+                ▼                        ▼
+┌─────┐      ┌─────┐                  ┌─────┐
+│  X  │─────▶│  D  │─────────────────▶│  E  │
+└─────┘      └─────┘                  └─────┘
+          ┌─────┴────┐              ┌────┴────┐
+          ▼          ▼              ▼         ▼
+       ┌─────┐    ┌─────┐        ┌─────┐   ┌─────┐
+       │  L  │    │  K  │        │  M  │   │  F  │
+       └─────┘    └─────┘        └─────┘   └─────┘
+*/
+function getGraph() {
+  return makeRoot()
+    .add({ a: () => new A(), x: () => new X() })
+    .add((ctx) => ({
+      b: () => new B(ctx.a),
+      c: () => new C(ctx.a),
+    }))
+    .add((ctx) => ({
+      d: () => new D(ctx.b, ctx.c, ctx.x),
+      m: async () => 123,
+    }))
+}
+/**
+ * warning, partial graph disposal should not be implemented
+ *
+ * Due to teh async nature of the problem, the only way to implement it is to
+ * track dependencies and dispose them in the reverse order of creation. Visitor pattern.
+ * But since there might multiple async resolution requests, we might accidentally "track"
+ * an unrelated dependency as a "visited" one.
+ *
+ * Hence when disposing, we would dispose unrelated dependencies as well.
+ *
+ * I don't think it would be really that useful anyway.
+ *
+ */
+describe("Disposing graph: [warning, this should never be implemented]", () => {
+  let root = getGraph()
+  beforeEach(() => {
+    root = getGraph()
+  })
+
+  it("should call graph", async () => {
+    const disposeLog: string[] = []
+    const dis = (token: string) => disposeLog.push(token)
+    const node = root.addDisposer((ctx, node) => ({
+      a: () => dis("a"),
+      b: () => dis("b"),
+      c: () => dis("c"),
+      d: () => dis("d"),
+      x: (x) => {
+        return dis("x")
+      },
+    }))
+
+    const d = node.get("d")
+    node.dispose("d")
+
+    expect(d).toBeInstanceOf(D)
+  })
+})

--- a/iti/tests/dispose.ts.api.spec.ts
+++ b/iti/tests/dispose.ts.api.spec.ts
@@ -100,7 +100,7 @@ describe("Disposing: ", () => {
   })
 })
 
-describe("Disposing graph: ", () => {
+describe("Individual disposing: ", () => {
   let root = makeRoot()
   let disposerOfA = jest.fn()
   let node = root.add({ a: "A" }).addDisposer({ a: disposerOfA })
@@ -130,6 +130,25 @@ describe("Disposing graph: ", () => {
     expect(disposerOfA).toHaveBeenCalledTimes(1)
   })
 
+  it("should emit a dispose event when disposed", () => {
+    return new Promise(async (resolve) => {
+      node.get("a")
+      node.on("containerDisposed", (payload) => {
+        expect(payload.key).toBe("a")
+        resolve(true)
+      })
+      node.dispose("a")
+    })
+  })
+})
+
+describe("Disposing graph: ", () => {
+  let root = makeRoot()
+
+  beforeEach(() => {
+    root = makeRoot()
+  })
+
   class DB {
     public connected = false
     constructor() {}
@@ -143,7 +162,7 @@ describe("Disposing graph: ", () => {
     }
   }
 
-  it("should call async dispose with correct instances and correct times", async () => {
+  it.skip("should call async dispose with correct instances and correct times", async () => {
     const disposerDb = jest.fn()
     const node = makeRoot()
       .add({

--- a/iti/tests/dispose.ts.api.spec.ts
+++ b/iti/tests/dispose.ts.api.spec.ts
@@ -1,0 +1,101 @@
+import { expect, jest, describe, beforeEach, it } from "@jest/globals"
+import { makeRoot } from "../src"
+import { wait } from "./_utils"
+
+describe("Disposing: ", () => {
+  let root: ReturnType<typeof makeRoot>
+
+  beforeEach(() => {
+    root = makeRoot()
+  })
+
+  class DB {
+    public connected = false
+    constructor() {}
+    async connect() {
+      this.connected = true
+      await wait(10)
+    }
+    async disconnect() {
+      await wait(20)
+      this.connected = false
+    }
+  }
+
+  it("should be able to call disposeAll", async () => {
+    const disposers = {
+      a: jest.fn(),
+      db: jest.fn(),
+    }
+    let r = root
+      .add({ x: "test", y: null })
+      .add({
+        a: "A",
+        b: null,
+        db: async () => {
+          const db = new DB()
+          await db.connect()
+          return db
+        },
+      })
+      .addDisposer((ctx) => ({
+        db: (db) => {
+          disposers.db()
+          return db.disconnect()
+        },
+        a: () => disposers.a(),
+      }))
+
+    const db = await r.get("db")
+    expect(db.connected).toBe(true)
+
+    await r.disposeAll()
+    expect(db.connected).toBe(false)
+
+    expect(r.get("a")).toBe("A")
+    await wait(3)
+    expect(disposers.db).toHaveBeenCalledTimes(1)
+    expect(disposers.a).toHaveBeenCalledTimes(0)
+  })
+
+  it("should NOT call dispose on items we have not resolved", async () => {
+    const disposers = {
+      a: jest.fn(),
+      db: jest.fn(),
+    }
+
+    let r = root
+      .add({
+        a: "A",
+        db: () => new DB(),
+      })
+      .addDisposer((ctx) => ({
+        db: (db) => {
+          disposers.db()
+          return db.disconnect()
+        },
+        a: () => disposers.a(),
+      }))
+
+    await r.get("db")
+    await r.disposeAll()
+    expect(disposers.db).toHaveBeenCalledTimes(1)
+    expect(disposers.a).not.toHaveBeenCalled()
+  })
+
+  it("should throw if we add the same disposers", async () => {
+    root
+      .add({
+        a: "A",
+      })
+      .addDisposer(() => ({
+        a: () => {},
+      }))
+
+    expect(() => {
+      root.addDisposer(() => ({
+        a: () => {},
+      }))
+    }).toThrow()
+  })
+})

--- a/iti/tests/dispose.ts.api.spec.ts
+++ b/iti/tests/dispose.ts.api.spec.ts
@@ -162,7 +162,7 @@ describe("Disposing graph: ", () => {
     }
   }
 
-  it.skip("should call async dispose with correct instances and correct times", async () => {
+  it("should call async dispose with correct instances and correct times", async () => {
     const disposerDb = jest.fn()
     const node = makeRoot()
       .add({

--- a/iti/tests/dispose.ts.api.spec.ts
+++ b/iti/tests/dispose.ts.api.spec.ts
@@ -142,7 +142,7 @@ describe("Individual disposing: ", () => {
   })
 })
 
-describe("Disposing graph: ", () => {
+describe("Disposing complex async: ", () => {
   let root = makeRoot()
 
   beforeEach(() => {

--- a/iti/tests/mock-graph.ts
+++ b/iti/tests/mock-graph.ts
@@ -1,0 +1,33 @@
+/*
+             ┌─────┐
+             │  A  │
+             └─────┘
+       ┌────────┴────────┐
+       ▼                 ▼
+    ┌─────┐           ┌─────┐
+    │  B  │           │  C  │────────────┐
+    └─────┘           └─────┘            │
+       └────────┬────────┘               │
+                ▼                        ▼
+┌─────┐      ┌─────┐                  ┌─────┐
+│  X  │─────▶│  D  │─────────────────▶│  E  │
+└─────┘      └─────┘                  └─────┘
+          ┌─────┴────┐              ┌────┴────┐
+          ▼          ▼              ▼         ▼
+       ┌─────┐    ┌─────┐        ┌─────┐   ┌─────┐
+       │  L  │    │  K  │        │  M  │   │  F  │
+       └─────┘    └─────┘        └─────┘   └─────┘
+*/
+
+class A {}
+class X {}
+class B { constructor(a: A) {} }
+class C { constructor(a: A) {} }
+class D { constructor(b: B, c: C, x: X) {} }
+class L { constructor(d: D) {} }
+class K { constructor(d: D) {} }
+class E { constructor(c: C, d: D) {} }
+class M { constructor(e: E) {} }
+class F { constructor(e: E) {} }
+
+export { A, X, B, C, D, L, K, E, M, F }

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
   },
   "author": "Nick Olszanski <nick@dinosaurs-with-jetpacks.club>",
   "license": "MIT",
-  "packageManager": "yarn@1.22.17"
+  "packageManager": "yarn@1.22.17",
+  "dependencies": {
+    "prettier": "^2.7.1"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8439,6 +8439,11 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
+prettier@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
+  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
+
 pretty-bytes@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-3.0.1.tgz#27d0008d778063a0b4811bb35c79f1bd5d5fbccf"


### PR DESCRIPTION
Related to a conversation with @moltar
https://github.com/molszanski/iti/issues/21

Propblem

```ts
class DatabaseConnection {
  disconnect(): Promise<void> {
    // ... disconnect
  }
}

let node = makeRoot()
  .add({
    db: () => new DatabaseConnection(),
  })
  .dispose({
    db: (containers) => containers.db.disconnect(),
  })

// disposes of for all resources that have it defined
await node.dispose()

// under the hood (internals)
class Node {
  async dispose(): Promise<void> {
    await Promise.all(this.getDisposableResources().map((r) => r()))
  }
}
```