### PR TITLE
fix: commonjs compatibility, nodenext type resolution

### DIFF
--- a/examples/node-cli/package.json
+++ b/examples/node-cli/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "dependencies": {
     "debug": "^4.3.3",
+    "iti": "0.6.0",
     "lodash": "^4.17.21",
     "mobx": "^6.3.12",
     "nodemon": "^2.0.15",
-    "iti": "0.6.0",
     "react": "^17.0.2",
     "ts-node": "^10.4.0",
     "typescript": "^4.5.5"

--- a/iti/package.json
+++ b/iti/package.json
@@ -21,7 +21,7 @@
   ],
   "scripts": {
     "_build": "rm -rf ./dist && microbundle build -o dist/ && cp -R src/* dist/src",
-    "build": "rm -rf ./dist microbundle build && cp dist/index.d.ts dist/index.d.cts",
+    "build": "rm -rf ./dist && microbundle build && cp dist/index.d.ts dist/index.d.cts",
     "jest": "jest",
     "stryker": "stryker",
     "stryker:run": "stryker run",

--- a/iti/package.json
+++ b/iti/package.json
@@ -5,19 +5,23 @@
   "type": "module",
   "sideEffects": false,
   "source": "src/index.ts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.modern.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    "require": "./dist/iti.cjs",
-    "default": "./dist/iti.modern.js"
+    "require": { 
+        "default": "./dist/index.cjs",
+        "types": "./dist/index.d.cts"
+    },
+    "import": "./dist/index.modern.js",
+    "types": "./dist/index.d.ts"
   },
-  "main": "./dist/iti.cjs",
-  "module": "./dist/iti.module.js",
-  "typings": "./dist/src/index.d.ts",
   "files": [
     "dist"
   ],
   "scripts": {
     "_build": "rm -rf ./dist && microbundle build -o dist/ && cp -R src/* dist/src",
-    "build": "rm -rf ./dist && microbundle build -o dist/",
+    "build": "microbundle build && cp dist/index.d.ts dist/index.d.cts",
     "jest": "jest",
     "stryker": "stryker",
     "stryker:run": "stryker run",
@@ -35,9 +39,9 @@
     "@types/jest": "^27.4.1",
     "@types/react": "^18.0.15",
     "jest": "^27.4.7",
-    "stryker-cli": "^1.0.2",
     "microbundle": "^0.15.0",
     "nodemon": "^2.0.19",
+    "stryker-cli": "^1.0.2",
     "ts-jest": "^27.1.3",
     "tsd": "^0.22.0",
     "typescript": "^4.7.4"

--- a/iti/package.json
+++ b/iti/package.json
@@ -21,7 +21,7 @@
   ],
   "scripts": {
     "_build": "rm -rf ./dist && microbundle build -o dist/ && cp -R src/* dist/src",
-    "build": "microbundle build && cp dist/index.d.ts dist/index.d.cts",
+    "build": "rm -rf ./dist microbundle build && cp dist/index.d.ts dist/index.d.cts",
     "jest": "jest",
     "stryker": "stryker",
     "stryker:run": "stryker run",

--- a/iti/tsconfig.json
+++ b/iti/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "ESNext",
     "outDir": "dist/",
+    "baseUrl": "./src/",
     "declarationDir": "dist/",
     "lib": [
       "dom",
@@ -25,9 +26,5 @@
     "declaration": true,
     "jsx": "react"
   },
-  "include": [
-    "src/**/*",
-    "tests/**/*",
-  ],
   "exclude":["node_modules"]
 }


### PR DESCRIPTION
this SHOULD resolve #38 #37 
Here was the issue with iti's resolution

https://arethetypeswrong.github.io/?p=iti%400.6.0


Changes
- output file name is `index.*.js` instead of iti.*.js
- changing the package.json to properly handle all module resolutions
- change the build script to fix commonjs resolution
Fixes 
- nodenext module resolution
- commonjs interop
- node16 type detection (still a little shaky per the website)
- bundler module resolution
I tested locally.
I have a package that depends on iti, and it compiles succesfully with the bundler moduleResolution.

I tested my package with applications in the follow pairs (module system, module resolution) : (commonjs, node) (commonjs, nodenext) (esm, nodenext), (esm, node)