### PR TITLE
[codex] Cover concurrent cache and React cleanup

### DIFF
--- a/iti-react/package.json
+++ b/iti-react/package.json
@@ -36,6 +36,8 @@
     "utility-types": "^3.10.0"
   },
   "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.3",
     "microbundle": "^0.15.1"
   },
   "peerDependencies": {

--- a/iti-react/tests/react-cleanup-and-rerenders.test.ts
+++ b/iti-react/tests/react-cleanup-and-rerenders.test.ts
@@ -1,0 +1,112 @@
+import React, { createElement } from "react"
+import { createContainer } from "iti"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { cleanup, fireEvent, render, screen, waitFor } from "./test-utils"
+import { getContainerHooks } from "../src/react/library.hook-generator"
+
+const h = createElement
+
+afterEach(cleanup)
+
+describe("React hook subscriptions", () => {
+  it("only rerenders consumers of the updated item", async () => {
+    const container = createContainer().add({
+      counter: 0,
+      message: "initial",
+    })
+    const ContainerContext = React.createContext(container)
+    const { useItem } = getContainerHooks(ContainerContext)
+    const counterRender = vi.fn()
+    const messageRender = vi.fn()
+
+    function Counter() {
+      counterRender()
+      const [counter] = useItem().counter
+      return h("span", null, `Counter: ${counter}`)
+    }
+
+    function Message() {
+      messageRender()
+      const [message] = useItem().message
+      return h("span", null, `Message: ${message}`)
+    }
+
+    function Controls() {
+      return h(
+        React.Fragment,
+        null,
+        h(
+          "button",
+          { onClick: () => container.upsert({ counter: 1 }) },
+          "Update counter",
+        ),
+        h(
+          "button",
+          { onClick: () => container.upsert({ message: "updated" }) },
+          "Update message",
+        ),
+      )
+    }
+
+    render(
+      h(
+        ContainerContext.Provider,
+        { value: container },
+        h(Counter),
+        h(Message),
+        h(Controls),
+      ),
+    )
+
+    await screen.findByText("Counter: 0")
+    await screen.findByText("Message: initial")
+    const initialCounterRenders = counterRender.mock.calls.length
+    const initialMessageRenders = messageRender.mock.calls.length
+
+    fireEvent.click(screen.getByRole("button", { name: "Update counter" }))
+    await screen.findByText("Counter: 1")
+    expect(counterRender).toHaveBeenCalledTimes(initialCounterRenders + 1)
+    expect(messageRender).toHaveBeenCalledTimes(initialMessageRenders)
+
+    fireEvent.click(screen.getByRole("button", { name: "Update message" }))
+    await screen.findByText("Message: updated")
+    expect(counterRender).toHaveBeenCalledTimes(initialCounterRenders + 1)
+    expect(messageRender).toHaveBeenCalledTimes(initialMessageRenders + 1)
+  })
+
+  it("unsubscribes every item listener when the consumer unmounts", async () => {
+    const container = createContainer().add({ counter: 0 })
+    const ContainerContext = React.createContext(container)
+    const { useItem } = getContainerHooks(ContainerContext)
+    const originalSubscribe = container.subscribeToItem.bind(container)
+    const unsubscribers: ReturnType<typeof vi.fn>[] = []
+
+    vi.spyOn(container, "subscribeToItem").mockImplementation((token, cb) => {
+      const unsubscribe = vi.fn(originalSubscribe(token, cb))
+      unsubscribers.push(unsubscribe)
+      return unsubscribe
+    })
+
+    function Counter() {
+      const [counter] = useItem().counter
+      return h("span", null, `Counter: ${counter}`)
+    }
+
+    const rendered = render(
+      h(ContainerContext.Provider, { value: container }, h(Counter)),
+    )
+
+    await screen.findByText("Counter: 0")
+    expect(unsubscribers.length).toBeGreaterThan(0)
+
+    rendered.unmount()
+
+    await waitFor(() => {
+      expect(
+        unsubscribers.every(
+          (unsubscribe) => unsubscribe.mock.calls.length === 1,
+        ),
+      ).toBe(true)
+    })
+  })
+})

--- a/iti/src/iti.ts
+++ b/iti/src/iti.ts
@@ -104,7 +104,9 @@ class InternalContainer<
 
     if (v instanceof Promise) {
       v.then((resolvedValue) => {
-        this._storeInSyncCache(token, resolvedValue)
+        if (this._cache[token] === v) {
+          this._storeInSyncCache(token, resolvedValue)
+        }
       }).catch((err) => {
         // we should't do anything with an error here
         // because this is our internal cache
@@ -180,6 +182,7 @@ class InternalContainer<
   ): Container<Omit<Context, SearchToken>, DisposeContext> {
     delete this._context[token]
     delete this._cache[token]
+    delete this._cacheSync[token]
     // There is no need to check for disposer existence, since delete will not throw
     // @ts-expect-error
     delete this._disposeCtx[token]
@@ -212,6 +215,7 @@ class InternalContainer<
 
       const cleanup = () => {
         delete this._cache[token]
+        delete this._cacheSync[token]
         this.ee.emit("containerDisposed", { key: token })
         this.ee.emit("itemDisposed", { key: token })
       }
@@ -256,6 +260,7 @@ class InternalContainer<
       // Save state and clear cache
       this._context[token] = value
       delete this._cache[token]
+      delete this._cacheSync[token]
       this.ee.emit("containerUpserted", {
         key: token as any,
         newContainer: value,

--- a/iti/tests/async-cache-invalidation.vi.spec.ts
+++ b/iti/tests/async-cache-invalidation.vi.spec.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest"
+import { createContainer } from "../src/iti"
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+describe("Async cache invalidation", () => {
+  it("does not let a replaced pending provider overwrite the sync cache", async () => {
+    const oldPending = deferred<{ version: string }>()
+    const oldService = { version: "old" }
+    const newService = { version: "new" }
+    const container = createContainer().add({
+      service: () => oldPending.promise,
+    })
+
+    const oldRead = container.get("service")
+    container.upsert({ service: async () => newService })
+    await expect(container.get("service")).resolves.toBe(newService)
+
+    oldPending.resolve(oldService)
+    await expect(oldRead).resolves.toBe(oldService)
+
+    expect(container.getSync("service")).toBe(newService)
+  })
+
+  it("invalidates a resolved async value when its provider is replaced", async () => {
+    const oldService = { version: "old" }
+    const newService = { version: "new" }
+    const container = createContainer().add({
+      service: async () => oldService,
+    })
+
+    await expect(container.get("service")).resolves.toBe(oldService)
+    expect(container.getSync("service")).toBe(oldService)
+
+    container.upsert({ service: async () => newService })
+    const replacement = container.getSync("service")
+
+    expect(replacement).toBeInstanceOf(Promise)
+    await expect(replacement).resolves.toBe(newService)
+  })
+
+  it("invalidates a resolved async value after disposal", async () => {
+    let instance = 0
+    const disposer = vi.fn()
+    const container = createContainer()
+      .add({
+        service: async () => ({ instance: ++instance }),
+      })
+      .addDisposer({ service: disposer })
+
+    const first = await container.get("service")
+    expect(container.getSync("service")).toBe(first)
+
+    await container.dispose("service")
+    const replacement = container.getSync("service")
+
+    expect(disposer).toHaveBeenCalledOnce()
+    expect(replacement).toBeInstanceOf(Promise)
+    await expect(replacement).resolves.toEqual({ instance: 2 })
+  })
+})

--- a/iti/tests/concurrent-access.vi.spec.ts
+++ b/iti/tests/concurrent-access.vi.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest"
+import { createContainer } from "../src/iti"
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+describe("Concurrent async access", () => {
+  it("shares one pending provider result between get calls", async () => {
+    const pending = deferred<{ id: number }>()
+    const provider = vi.fn(() => pending.promise)
+    const container = createContainer().add({ service: provider })
+
+    const reads = Array.from({ length: 10 }, () => container.get("service"))
+
+    expect(provider).toHaveBeenCalledTimes(1)
+    expect(reads.every((read) => read === reads[0])).toBe(true)
+
+    const service = { id: 1 }
+    pending.resolve(service)
+    const results = await Promise.all(reads)
+
+    expect(results.every((result) => result === service)).toBe(true)
+  })
+
+  it("shares pending providers between overlapping getItems calls", async () => {
+    const pendingA = deferred<{ name: string }>()
+    const pendingB = deferred<{ name: string }>()
+    const providerA = vi.fn(() => pendingA.promise)
+    const providerB = vi.fn(() => pendingB.promise)
+    const container = createContainer().add({
+      serviceA: providerA,
+      serviceB: providerB,
+    })
+
+    const first = container.getItems(["serviceA", "serviceB"])
+    const second = container.getItems(["serviceB"])
+
+    expect(providerA).toHaveBeenCalledTimes(1)
+    expect(providerB).toHaveBeenCalledTimes(1)
+
+    const serviceA = { name: "A" }
+    const serviceB = { name: "B" }
+    pendingA.resolve(serviceA)
+    pendingB.resolve(serviceB)
+
+    await expect(first).resolves.toEqual({ serviceA, serviceB })
+    await expect(second).resolves.toEqual({ serviceB })
+  })
+})


### PR DESCRIPTION
## Describe your changes

This is the first change targeting the `0.8.1` release-candidate branch.

PR #50 proposed broad concurrency, cache, and React cleanup coverage. This rebuilds the useful cases as focused tests against current `master`:

- concurrent `get` and overlapping `getItems` calls reuse pending providers
- replacing or disposing an async provider invalidates its resolved sync cache
- a replaced pending provider cannot overwrite the replacement value after resolving
- React item consumers only rerender for their subscribed token and unsubscribe on unmount

The React tests use Testing Library and contain no explicit `act` calls. Existing React tests and helpers are unchanged.

The cache tests exposed a stale-value bug in `_cacheSync`. `upsert`, `delete`, and `dispose` now clear that cache, and promise resolution only writes to it while the promise is still the active cached provider.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I did run tests on the whole monorepo

## Test plan

- [x] `cd iti && yarn test:ci`
- [x] `cd iti && yarn build`
- [x] `cd iti-react && yarn test`
- [x] `cd iti-react && yarn build`
- [x] `yarn test`
- [x] `yarn build`
